### PR TITLE
Adds dynamodb local delete table and renames table creation command

### DIFF
--- a/lib/stax/mixin/dynamodb/local.rb
+++ b/lib/stax/mixin/dynamodb/local.rb
@@ -57,10 +57,10 @@ module Stax
         end
       end
 
-      desc 'local', 'create local tables from template'
+      desc 'local-create', 'create local tables from template'
       method_option :tables,  aliases: '-t', type: :array,   default: nil,   desc: 'filter table ids'
       method_option :payload, aliases: '-p', type: :boolean, default: false, desc: 'just output payload'
-      def local
+      def local_create
         tables = dynamo_local_tables
         tables.slice!(*options[:tables]) if options[:tables]
 
@@ -73,6 +73,18 @@ module Stax
             puts "create table #{id}"
             dynamo_local_create(payload)
           end
+        end
+      end
+
+      desc 'local-delete', 'delete local tables from template'
+      method_option :tables,  aliases: '-t', type: :array, default: nil, desc: 'filter table ids'
+      def local_delete
+        tables = dynamo_local_tables
+        tables.slice!(*options[:tables]) if options[:tables]
+
+        tables.each do |id,_value|
+          puts "deleting table #{id}"
+          client.delete_table(table_name: id)
         end
       end
 


### PR DESCRIPTION
This is to fully use stax and avoid other workarounds to delete tables
And the rename part is just to avoid confusion con calling those commands:

![screen shot 2018-06-20 at 15 47 10](https://user-images.githubusercontent.com/101831/41678699-25e9612a-74a2-11e8-89e9-7577694b71d0.png)
