### PR TITLE
Handle AWS Cloudformation Throttling More Gracefully

### DIFF
--- a/lib/stax/aws/cfn.rb
+++ b/lib/stax/aws/cfn.rb
@@ -31,7 +31,7 @@ module Stax
       class << self
 
         def client
-          @_client ||= ::Aws::CloudFormation::Client.new
+          @_client ||= ::Aws::CloudFormation::Client.new(retry_limit: Stax::Aws::Sdk::RETRY_LIMIT)
         end
 
         def stacks

--- a/lib/stax/aws/sdk.rb
+++ b/lib/stax/aws/sdk.rb
@@ -2,6 +2,8 @@ module Stax
   module Aws
     class Sdk
 
+      RETRY_LIMIT = ENV['AWS_RETRY_LIMIT'] || 100
+
       ## universal paginator for aws-sdk calls
       def self.paginate(thing)
         token = nil

--- a/lib/stax/version.rb
+++ b/lib/stax/version.rb
@@ -1,3 +1,3 @@
 module Stax
-  VERSION = '0.0.23'
+  VERSION = '0.0.24'
 end


### PR DESCRIPTION
We see frequently errors due to AWS throttling. Increasing the number of retries (the default was set to 3 retries) resolves the problem. The sdk does an exponential backoff, and 3 retries was not sufficient for our needs.

#### Considerations
This PR only increases the number of retries for cloudformation, but potentially, many of the AWS services may benefit from an increase in the retry limit. Additionally, I didn't see an established way for user configuration of such a constant (though imagine this could be set via the Staxfile. I chose to make it configurable via ENV var, but I can change that if there is a more preferred way. Lastly, I arbitrarily made the retry limit very high (100). The thought here was `ctrl-c` is your friend, but I honestly have no idea what a reasonable retry limit should be.