### PR TITLE
Change env var name to make it clear not official AWS env

### DIFF
--- a/lib/stax/aws/sdk.rb
+++ b/lib/stax/aws/sdk.rb
@@ -2,7 +2,7 @@ module Stax
   module Aws
     class Sdk
 
-      RETRY_LIMIT = ENV['AWS_RETRY_LIMIT'] || 100
+      RETRY_LIMIT = ENV['STAX_RETRY_LIMIT'] || 100
 
       ## universal paginator for aws-sdk calls
       def self.paginate(thing)


### PR DESCRIPTION
The env var name `AWS_RETRY_LIMIT` could be confusing as it looks like an official AWS env var that might apply to all SDKs and CLI. Changing the name makes it clear it is stax-only.

Cc: @dissolved 