### PR TITLE
Update 'lambda test' tail option default value

### DIFF
--- a/lib/stax/mixin/lambda.rb
+++ b/lib/stax/mixin/lambda.rb
@@ -83,7 +83,7 @@ module Stax
 
       desc 'test ID', 'run lambda with ID'
       method_option :type,    type: :string,  default: nil,   desc: 'invocation type: RequestResponse, Event'
-      method_option :tail,    type: :boolean, default: false, desc: 'tail log for RequestResponse'
+      method_option :tail,    type: :boolean, default: nil,   desc: 'tail log for RequestResponse'
       method_option :payload, type: :string,  default: nil,   desc: 'json input to function'
       method_option :file,    type: :string,  default: nil,   desc: 'get json payload from file'
       def test(id)

--- a/lib/stax/version.rb
+++ b/lib/stax/version.rb
@@ -1,3 +1,3 @@
 module Stax
-  VERSION = '0.0.27'
+  VERSION = '0.0.28'
 end


### PR DESCRIPTION
Calling `test` through Thor's `invoke` method has unexpected behavior when passing a `:tail` option.

Before this change, regardless of what options are passed to invoke, `options[:tail]` comes out as false. With this change, there is no key for `:tail` in options if nothing is passed in the options hash, and if `:tail` is passed, it comes through as expected.