### PR TITLE
Stop tailing codepipeline when steady state.

### DIFF
--- a/lib/stax/mixin/codepipeline.rb
+++ b/lib/stax/mixin/codepipeline.rb
@@ -111,6 +111,7 @@ module Stax
         name ||= my.stack_pipeline_names.first
         last_seen = nil
         loop do
+          sleep 5
           state = Aws::Codepipeline.state(name)
           now = Time.now
           stages = state.stage_states.map do |s|
@@ -120,7 +121,14 @@ module Stax
             [s.stage_name, color(s&.latest_execution&.status || '', COLORS), "#{ago} ago", revisions].join(' ')
           end
           puts [set_color(now, :blue), stages].flatten.join('  ')
-          sleep 5
+          if stages.none? { |stage| stage.match? /InProgress/ }
+            if stages.all? { |stage| stage.match? /Succeeded/ }
+              puts set_color("All stages succeeded!", :green)
+            else
+              puts set_color("Pipeline did not complete successfully.", :red)
+            end
+            break
+          end
         end
       end
 


### PR DESCRIPTION
You may have another way to accomplish this... but seems to work on my machine. Only concern is if there is a race condition where none of the stages report "InProgress" but all stages haven't completed.