### PR TITLE
Auto require base and stack libs

### DIFF
--- a/lib/stax/staxfile.rb
+++ b/lib/stax/staxfile.rb
@@ -29,8 +29,17 @@ module Stax
     @@_root_path = find_staxfile
     if root_path
       load(root_path.join('Staxfile'))
+      require_libs
       require_stacks
       require_commands
+    end
+  end
+
+  ## auto-require class overrides
+  def self.require_libs
+    %w[ base stack ].each do |file|
+      f = root_path.join('lib', "#{file}.rb")
+      require(f) if File.exist?(f)
     end
   end
 


### PR DESCRIPTION
We frequently need to require `ops/lib/base.rb` and `ops/lib/stack.rb`. Make this automatic: less code and more consistent with `ops/lib/stack/*.rb` stack auto-requires.