### PR TITLE
Remove deprecated method alias

### DIFF
--- a/lib/stax/stack/template.rb
+++ b/lib/stax/stack/template.rb
@@ -14,21 +14,21 @@ module Stax
 
       ## load a yaml template
       def cfn_template_yaml
-        if File.exists?(f = "#{cfn_template_stub}.yaml")
+        if File.exist?(f = "#{cfn_template_stub}.yaml")
           File.read(f)
         end
       end
 
       ## load a json template
       def cfn_template_json
-        if File.exists?(f = "#{cfn_template_stub}.json")
+        if File.exist?(f = "#{cfn_template_stub}.json")
           File.read(f)
         end
       end
 
       ## load a ruby cfer template
       def cfn_template_cfer
-        if File.exists?(f = "#{cfn_template_stub}.rb")
+        if File.exist?(f = "#{cfn_template_stub}.rb")
           cfer_generate(f)
         end
       end


### PR DESCRIPTION
`File.exists?` was removed as an alias to `File.exist?` in Ruby 3.2.

See: https://bugs.ruby-lang.org/issues/17391