### PR TITLE
feat: add RDS blue/green deployment management commands to RDS mixin

### DIFF
--- a/lib/stax/mixin/rds.rb
+++ b/lib/stax/mixin/rds.rb
@@ -225,9 +225,7 @@ module Stax
           # tail the blue/green deployment until it is deleted
           begin
             invoke(:tail_upgrade_candidate, [], id: deployment_identifier)
-          # TODO: figure out how to catch this specific exception
-          # rescue Aws::RDS::Errors::BlueGreenDeploymentNotFoundFault
-          rescue  
+          rescue ::Aws::RDS::Errors::BlueGreenDeploymentNotFoundFault
             say("Deleted blue/green deployment #{deployment_identifier}", :green)
           end
         end


### PR DESCRIPTION
This adds four new commands to the RDS mixin to support managing [RDS blue/green deployments](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/blue-green-deployments-overview.html).

- `stax <db-stack> rds create-upgrade-candidate`
- `stax <db-stack> rds delete-upgrade-candidate`
- `stax <db-stack> rds switchover-upgrade-candidate`
- `stax <db-stack> rds tail-upgrade-candidate`

These four commands each more or less map to the four RDS API client methods for blue/green deployments.
- [#create_blue_green_deployment](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/RDS/Client.html#create_blue_green_deployment-instance_method)
- [#delete_blue_green_deployment](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/RDS/Client.html#delete_blue_green_deployment-instance_method)
- [#switchover_blue_green_deployment](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/RDS/Client.html#switchover_blue_green_deployment-instance_method)
- [#describe_blue_green_deployments](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/RDS/Client.html#describe_blue_green_deployments-instance_method)

The basic workflow is you'd start by running `stax <db-stack> rds create-upgrade-candidate` with, or without an upgraded engine version/parameter group.

From there you have time to manually validate the upgrade candidate (green deployment) and when ready to cutover you'll run `stax <db-stack> rds switchover-upgrade-candidate`

Finally you can run `stax <db-stack> rds delete-upgrade-candidate` to delete the blue/green deployment resource. There's an optional `--delete-target` flag for the delete command that can automatically cleanup the green deployment's resources. This is only allowed prior to a successful switchover. The switchover is a one way operation and once complete while you can delete the meta resource for the blue/green deployment, you have to delete the "blue" deployment manually or via direct API calls to delete DB instances/cluster. I imagine this is a design decision by AWS to make it difficult to destroy the old version of a RDS DB post-upgrade since there's value in having a fallback candidate.

The `stax <db-stack> rds tail-upgrade-candidate` command prints event data from the describe_blue_green_deployments API call with artificial timestamps (the AWS API call for describing a b/g deployment is lacking in actual event timestamps).

Every 10s this function loops and checks if events have changed at all. If there are changes the updates get printed creating a linear history of the progress. Once a terminal status is found ("Available" or "Switchover Complete") the loop breaks.

The create, delete, and switchover commands all invoke the tail command after running their respective API calls to provide feedback on the asynchronous activity. A user can just interrupt the command once the "tail" portion is reached and the action will continue occurring in the background and can be checked in on via GUI or by running the `tail-upgrade-candidate` command again.

## Issues/Questions

### ~AWS error handling~
> [!NOTE]  
> I found the right syntax and fixed this in 8e3018f

When deleting a b/g deployment the "happy path" of the final iteration of polling for status changes will throw a `AWS::RDS::Errors::BlueGreenDeploymentNotFoundFault` (see: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DeleteBlueGreenDeployment.html) due to the b/g deployment being deleted successfully.

My first approach to this was:
```ruby
# tail the blue/green deployment until it is deleted
begin
  invoke(:tail_upgrade_candidate, [], id: deployment_identifier)
rescue Aws::RDS::Errors::BlueGreenDeploymentNotFoundFault
  say("Deleted blue/green deployment #{deployment_identifier}", :green)
end
```

This didn't work out because of ruby mannerisms that I haven't wrangled with much. Specifically:
```
stax/lib/stax/mixin/rds.rb:225:in `rescue in delete_upgrade_candidate': uninitialized constant Stax::Aws::RDS (NameError)
Did you mean?  Stax::Aws::Rds
               Stax::Rds
...
gems/aws-sdk-core-3.170.0/lib/seahorse/client/plugins/raise_response_errors.rb:17:in `call': Blue Green Deployment 'bgd-a1a1aaaaa1a1aaaa' doesn't exist. (Aws::RDS::Errors::BlueGreenDeploymentNotFoundFault)
```

As a stopgap I have it as just a broad `rescue` which "works", but swallows actual errors that would be worth throwing.

Someone with more ruby-fu can probably point me in the right direction to rescue the right value/reference the Aws::RDS error instead of getting stuck on Stax::Aws::RDS. 

### Filter issue with retrieving b/g deployments automatically

The `delete-upgrade-candidate`, `switchover-upgrade-candidate`, and `tail-upgrade-candidate` commands all have a required `--id` option for providing the ID of the b/g deployment to operate on. This isn't really ideal IMO and I'd prefer to just intrinsically detect the ID of an existing b/g deployment based on the stack. I tried this, but AWS/stax confounded me:
```ruby
def stack_bg_deployments
  filter = { name: 'source', values: stack_rds_clusters.map(&:db_cluster_arn) }
  Aws::Rds.client.describe_blue_green_deployments({ filters: [filter] }).blue_green_deployments
end
```
Trying this just threw a `Aws::RDS::Errors::InvalidParameterValue`:
```
gems/aws-sdk-core-3.170.0/lib/seahorse/client/plugins/raise_response_errors.rb:17:in `call': Only DB Instance Identifiers can be used with the filter DB_INSTANCE_ID (Aws::RDS::Errors::InvalidParameterValue)
```
I printed the `filter` to see if something was wrong with it and it _seems_ correct to me:
```ruby
{:name=>"source", :values=>["arn:aws:rds:us-east-1:111111111111:cluster:example-dbcluster-3bzapxxqwrnx"]}
```
The API Docs for the [DescribeBlueGreenDeployments](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeBlueGreenDeployments.html) say that a `source` filter is allowed.
>source - Accepts source databases for a blue/green deployment. The results list only includes information about the blue/green deployments with the specified source databases.

...seems weird. I might also just try a filter based on the name and see if that works, ie:
```ruby
filter = { name: 'blue-green-deployment-name', values: [ "#{my.stack_name}-next-*" ] }
```

Open to suggestions here though!

## Example Runs

Here are a few examples of the output from creating a b/g deployment while upgrading the engine version, switching over, and deleting.

### create-upgrade-candidate
```
❯ stax dbcluster rds create-upgrade-candidate --target-engine-version '13.12' --target-cluster-parameter-group 'example-dbparam-dbclusterparamgroup13-iqhtjziuqcou' --target-instance-parameter-group 'example-dbparam-dbinstanceparamgroup13-yxb7eyxc9ut5'

Creating blue/green deployment example-dbcluster-next-70fFhDeEijMM for arn:aws:rds:us-east-1:111111111111:cluster:example-dbcluster-jy5lomxfmoad
Deployment Name: example-dbcluster-next-70ffhdeeijmm
Deployment ID: bgd-a1a1aaaaa1a1aaaa
Create Time: 2023-11-14 17:57:38 UTC
2023-11-14 17:57:39 UTC  Deployment Status  PROVISIONING
2023-11-14 17:57:39 UTC  Pending DB Resource    PROVISIONING
2023-11-14 17:57:39 UTC  Pending DB Resource    PROVISIONING
2023-11-14 17:57:39 UTC  Pending DB Resource    PROVISIONING
2023-11-14 17:57:39 UTC  Task  CREATING_READ_REPLICA_OF_SOURCE  PENDING
2023-11-14 17:57:39 UTC  Task  DB_ENGINE_VERSION_UPGRADE  PENDING
2023-11-14 17:57:39 UTC  Task  CREATE_DB_INSTANCES_FOR_CLUSTER  PENDING
2023-11-14 17:58:22 UTC  DB Cluster  arn:aws:rds:us-east-1:111111111111:cluster:example-dbcluster-jy5lom-green-ibvrl1  CREATING
2023-11-14 17:58:22 UTC  Task  CREATING_READ_REPLICA_OF_SOURCE  IN_PROGRESS
2023-11-14 18:08:11 UTC  DB Cluster  arn:aws:rds:us-east-1:111111111111:cluster:example-dbcluster-jy5lom-green-ibvrl1  AVAILABLE
2023-11-14 18:08:11 UTC  DB Instance  arn:aws:rds:us-east-1:111111111111:db:example-dbcluster-dbinstance1-cue9-green-zxwd5a  CREATING
2023-11-14 18:20:33 UTC  DB Instance  arn:aws:rds:us-east-1:111111111111:db:example-dbcluster-dbinstance1-cue9-green-zxwd5a  AVAILABLE
2023-11-14 18:20:33 UTC  Task  CREATING_READ_REPLICA_OF_SOURCE  COMPLETED
2023-11-14 18:21:37 UTC  Task  DB_ENGINE_VERSION_UPGRADE  IN_PROGRESS
2023-11-14 18:37:53 UTC  Task  DB_ENGINE_VERSION_UPGRADE  COMPLETED
2023-11-14 18:38:47 UTC  DB Instance  arn:aws:rds:us-east-1:111111111111:db:example-dbcluster-dbinstance0-k1lx-green-ol2bpt  CREATING
2023-11-14 18:38:47 UTC  Task  CREATE_DB_INSTANCES_FOR_CLUSTER  IN_PROGRESS
2023-11-14 18:44:53 UTC  Deployment Status  AVAILABLE
2023-11-14 18:44:53 UTC  DB Instance  arn:aws:rds:us-east-1:111111111111:db:example-dbcluster-dbinstance0-k1lx-green-ol2bpt  AVAILABLE
2023-11-14 18:44:53 UTC  Task  CREATE_DB_INSTANCES_FOR_CLUSTER  COMPLETED
Deployment is complete.
```

### switchover-upgrade-candidate
```
❯ stax dbcluster rds switchover-upgrade-candidate --id bgd-a1a1aaaaa1a1aaaa

Really switchover blue/green deployment bgd-a1a1aaaaa1a1aaaa? y
Switchover blue/green deployment bgd-a1a1aaaaa1a1aaaa
Deployment Name: example-dbcluster-next-70ffhdeeijmm
Deployment ID: bgd-a1a1aaaaa1a1aaaa
Create Time: 2023-11-14 17:57:38 UTC
2023-11-14 19:26:40 UTC  Deployment Status  SWITCHOVER_IN_PROGRESS
2023-11-14 19:26:40 UTC  DB Cluster  arn:aws:rds:us-east-1:111111111111:cluster:example-dbcluster-jy5lom-green-ibvrl1  AVAILABLE
2023-11-14 19:26:40 UTC  DB Instance  arn:aws:rds:us-east-1:111111111111:db:example-dbcluster-dbinstance0-k1lx-green-ol2bpt  AVAILABLE
2023-11-14 19:26:40 UTC  DB Instance  arn:aws:rds:us-east-1:111111111111:db:example-dbcluster-dbinstance1-cue9-green-zxwd5a  AVAILABLE
2023-11-14 19:26:40 UTC  Task  CREATING_READ_REPLICA_OF_SOURCE  COMPLETED
2023-11-14 19:26:40 UTC  Task  DB_ENGINE_VERSION_UPGRADE  COMPLETED
2023-11-14 19:26:40 UTC  Task  CREATE_DB_INSTANCES_FOR_CLUSTER  COMPLETED
2023-11-14 19:26:51 UTC  DB Cluster  arn:aws:rds:us-east-1:111111111111:cluster:example-dbcluster-jy5lom-green-ibvrl1  SWITCHOVER_IN_PROGRESS
2023-11-14 19:26:51 UTC  DB Instance  arn:aws:rds:us-east-1:111111111111:db:example-dbcluster-dbinstance0-k1lx-green-ol2bpt  SWITCHOVER_IN_PROGRESS
2023-11-14 19:26:51 UTC  DB Instance  arn:aws:rds:us-east-1:111111111111:db:example-dbcluster-dbinstance1-cue9-green-zxwd5a  SWITCHOVER_IN_PROGRESS
2023-11-14 19:27:23 UTC  DB Cluster  arn:aws:rds:us-east-1:111111111111:cluster:example-dbcluster-jy5lomxfmoad  SWITCHOVER_IN_PROGRESS
2023-11-14 19:27:23 UTC  DB Instance  arn:aws:rds:us-east-1:111111111111:db:example-dbcluster-dbinstance0-k1lx9g7kx92q  SWITCHOVER_IN_PROGRESS
2023-11-14 19:27:23 UTC  DB Instance  arn:aws:rds:us-east-1:111111111111:db:example-dbcluster-dbinstance1-cue9y9jsubh7  SWITCHOVER_IN_PROGRESS
2023-11-14 19:29:21 UTC  Deployment Status  SWITCHOVER_COMPLETED
2023-11-14 19:29:21 UTC  DB Cluster  arn:aws:rds:us-east-1:111111111111:cluster:example-dbcluster-jy5lomxfmoad  SWITCHOVER_COMPLETED
2023-11-14 19:29:21 UTC  DB Instance  arn:aws:rds:us-east-1:111111111111:db:example-dbcluster-dbinstance0-k1lx9g7kx92q  SWITCHOVER_COMPLETED
2023-11-14 19:29:21 UTC  DB Instance  arn:aws:rds:us-east-1:111111111111:db:example-dbcluster-dbinstance1-cue9y9jsubh7  SWITCHOVER_COMPLETED
Deployment switchover is complete.
```

### delete-upgrade-candidate
```
❯ stax dbcluster rds delete-upgrade-candidate --id bgd-a1a1aaaaa1a1aaaa

Really delete blue/green deployment bgd-a1a1aaaaa1a1aaaa? y
Deleting blue/green deployment bgd-a1a1aaaaa1a1aaaa
Deployment Name: example-dbcluster-next-70ffhdeeijmm
Deployment ID: bgd-a1a1aaaaa1a1aaaa
Create Time: 2023-11-14 17:57:38 UTC
2023-11-14 19:45:02 UTC  Deployment Status  DELETING
2023-11-14 19:45:02 UTC  DB Cluster  arn:aws:rds:us-east-1:111111111111:cluster:example-dbcluster-dbcluster-jy5lomxfmoad  SWITCHOVER_COMPLETED
2023-11-14 19:45:02 UTC  DB Instance  arn:aws:rds:us-east-1:111111111111:db:example-dbcluster-dbinstance0-k1lx9g7kx92q  SWITCHOVER_COMPLETED
2023-11-14 19:45:02 UTC  DB Instance  arn:aws:rds:us-east-1:111111111111:db:example-dbcluster-dbinstance1-cue9y9jsubh7  SWITCHOVER_COMPLETED
2023-11-14 19:45:02 UTC  Task  CREATING_READ_REPLICA_OF_SOURCE  COMPLETED
2023-11-14 19:45:02 UTC  Task  DB_ENGINE_VERSION_UPGRADE  COMPLETED
2023-11-14 19:45:02 UTC  Task  CREATE_DB_INSTANCES_FOR_CLUSTER  COMPLETED
Deleted blue/green deployment bgd-a1a1aaaaa1a1aaaa
```